### PR TITLE
[61][Frontend] useInterval을 사용한 로딩 시간표시 기능 및 DB에 폴더가 삭제된 경우 alert 및 리덕스 반영하는 기능구현 

### DIFF
--- a/src/components/List/Card.js
+++ b/src/components/List/Card.js
@@ -19,12 +19,7 @@ export default function Card({ folder, origin, setIsModalOpen }) {
     <FolderWrapper
       type="button"
       onClick={async (e) => {
-        // const isExist = await dispatch(isFolderExist(folder));
-        // if (!isExist) {
-        //   alert("삭제된 폴더입니다!")
-        //   // react spring transition logic
-        // }
-
+        // 여전히 조회는 가능하고, like button만 막음
         dispatch(selectFolder(folder));
 
         if (origin === "mainCategory") {

--- a/src/components/List/LikeButton.js
+++ b/src/components/List/LikeButton.js
@@ -15,7 +15,6 @@ export default function LikeButton({ folder, index, origin, category }) {
     if (data === "Folder Not Found") {
       alert("존재하지 않는 폴더입니다.");
 
-      dispatch(deleteFolder(folder._id));
       return;
     }
 

--- a/src/components/List/LikeButton.js
+++ b/src/components/List/LikeButton.js
@@ -1,13 +1,24 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { HeartOutlined, HeartFilled } from "@ant-design/icons";
-import { fetchCategoryFolder, handleLike } from "../../redux/slices/categoryFolderSlices";
+import { handleLike } from "../../redux/slices/categoryFolderSlices";
+import { deleteFolder } from "../../redux/slices/folderSlices";
+import req from "../../utils/api";
 
 export default function LikeButton({ folder, index, origin, category }) {
   const dispatch = useDispatch();
   const isChecked = useSelector((state) => state.categoryFolder.checkedFolder);
 
-  function handleClickLikeFolder() {
+  async function handleClickLikeFolder() {
+    const { data } = await req("get", `/folder/unique/${folder._id}`, {}, (res) => res, true);
+
+    if (data === "Folder Not Found") {
+      alert("존재하지 않는 폴더입니다.");
+
+      dispatch(deleteFolder(folder._id));
+      return;
+    }
+
     dispatch(handleLike([folder["_id"], index, origin]));
   }
 

--- a/src/components/List/LikeButton.js
+++ b/src/components/List/LikeButton.js
@@ -1,8 +1,7 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { HeartOutlined, HeartFilled } from "@ant-design/icons";
-import { handleLike } from "../../redux/slices/categoryFolderSlices";
-import { deleteFolder } from "../../redux/slices/folderSlices";
+import { handleLike, deleteUniqueCategoryFolder } from "../../redux/slices/categoryFolderSlices";
 import req from "../../utils/api";
 
 export default function LikeButton({ folder, index, origin, category }) {
@@ -14,6 +13,7 @@ export default function LikeButton({ folder, index, origin, category }) {
 
     if (data === "Folder Not Found") {
       alert("존재하지 않는 폴더입니다.");
+      dispatch(deleteUniqueCategoryFolder({ category, index }));
 
       return;
     }

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -1,7 +1,6 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
-import useInterval from "../../utils/useInterval";
 
 import Card from "./Card";
 import Modal from "../Modal/Modal";
@@ -49,15 +48,10 @@ export default function List({ category, origin }) {
   const selectedFolder = useSelector((state) => state.folder.selectedFolder);
   const fetchedCategoryFolder = useSelector((state) => state.categoryFolder.fetchedCategoryFolder);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [counter, setCounter] = useState(0);
 
   useEffect(() => {
     dispatch(fetchCategoryFolder({ origin, category }));
   }, []);
-
-  useInterval(() => {
-    dispatch(fetchCategoryFolder({ origin, category }));
-  }, process.env.REACT_APP_RANK_PAGE_LOADING_DELAY);
 
   return (
     <CardWrapper>

--- a/src/components/RankPage/MainRankPage/MainRankPage.js
+++ b/src/components/RankPage/MainRankPage/MainRankPage.js
@@ -27,7 +27,7 @@ export default function MainRankPage() {
       if (loadingTime === 0) {
         setIsRunning(false);
 
-        category.mainCategory.map(async (index) => {
+        category.mainCategory.map(async (element, index) => {
           await dispatch(
             fetchCategoryFolder({
               origin: "mainCategory",

--- a/src/components/RankPage/MainRankPage/MainRankPage.js
+++ b/src/components/RankPage/MainRankPage/MainRankPage.js
@@ -1,7 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import category from "../../../utils/category.json";
 import List from "../../List/List";
+import useInterval from "../../../utils/useInterval";
+import { updateSecond } from "../../../redux/slices/timerSlice";
+import { fetchCategoryFolder } from "../../../redux/slices/categoryFolderSlices";
 
 const ListWrapper = styled.div`
   display: flex;
@@ -14,6 +18,33 @@ const TitleWrapper = styled.h2`
 `;
 
 export default function MainRankPage() {
+  const [isRunning, setIsRunning] = useState(true);
+  const loadingTime = useSelector((state) => state.timer.second);
+  const dispatch = useDispatch();
+
+  // useInterval(
+  //   async () => {
+  //     if (loadingTime === 0) {
+  //       setIsRunning(false);
+
+  //       category.mainCategory.map(async (index) => {
+  //         await dispatch(
+  //           fetchCategoryFolder({
+  //             origin: "mainCategory",
+  //             category: category.mainCategory[index].name,
+  //           }),
+  //         );
+  //       });
+
+  //       dispatch(updateSecond(process.env.REACT_APP_RANK_PAGE_LOADING_DELAY / 1000));
+  //       setIsRunning(true);
+  //     } else {
+  //       dispatch(updateSecond(-1));
+  //     }
+  //   },
+  //   isRunning ? 1000 : null,
+  // );
+
   return (
     <ListWrapper>
       {category.mainCategory.map((element, index) => (

--- a/src/components/RankPage/MainRankPage/MainRankPage.js
+++ b/src/components/RankPage/MainRankPage/MainRankPage.js
@@ -22,28 +22,28 @@ export default function MainRankPage() {
   const loadingTime = useSelector((state) => state.timer.second);
   const dispatch = useDispatch();
 
-  // useInterval(
-  //   async () => {
-  //     if (loadingTime === 0) {
-  //       setIsRunning(false);
+  useInterval(
+    async () => {
+      if (loadingTime === 0) {
+        setIsRunning(false);
 
-  //       category.mainCategory.map(async (index) => {
-  //         await dispatch(
-  //           fetchCategoryFolder({
-  //             origin: "mainCategory",
-  //             category: category.mainCategory[index].name,
-  //           }),
-  //         );
-  //       });
+        category.mainCategory.map(async (index) => {
+          await dispatch(
+            fetchCategoryFolder({
+              origin: "mainCategory",
+              category: category.mainCategory[index].name,
+            }),
+          );
+        });
 
-  //       dispatch(updateSecond(process.env.REACT_APP_RANK_PAGE_LOADING_DELAY / 1000));
-  //       setIsRunning(true);
-  //     } else {
-  //       dispatch(updateSecond(-1));
-  //     }
-  //   },
-  //   isRunning ? 1000 : null,
-  // );
+        dispatch(updateSecond(process.env.REACT_APP_RANK_PAGE_LOADING_DELAY / 1000));
+        setIsRunning(true);
+      } else {
+        dispatch(updateSecond(-1));
+      }
+    },
+    isRunning ? 1000 : null,
+  );
 
   return (
     <ListWrapper>

--- a/src/components/RankPage/RankPage.js
+++ b/src/components/RankPage/RankPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
 
@@ -25,15 +25,18 @@ const CounterWrapper = styled.div`
 
 export default function RankPage() {
   const keyword = useSelector((state) => state.keyword.keyword);
+  const loadingTime = useSelector((state) => state.timer.second);
 
   return (
     <div>
       <RankHeader>
         <SearchBar />
-        <LoaderWrapper>
-          <Loader height={30} width={30} />
-          {/* <CounterWrapper>{second / 1000}초 뒤 업데이트</CounterWrapper> */}
-        </LoaderWrapper>
+        {!keyword && (
+          <LoaderWrapper>
+            <Loader height={30} width={30} />
+            <CounterWrapper>{loadingTime}초 뒤 업데이트</CounterWrapper>
+          </LoaderWrapper>
+        )}
       </RankHeader>
       {!keyword ? <MainRankPage /> : <SubRankPage />}
     </div>

--- a/src/redux/slices/categoryFolderSlices.js
+++ b/src/redux/slices/categoryFolderSlices.js
@@ -45,7 +45,13 @@ const categoryFolderSlices = createSlice({
     fetchedCategoryFolder: {},
     checkedFolder: {},
   },
-  reducers: {},
+  reducers: {
+    deleteUniqueCategoryFolder: (state, action) => {
+      const { category, index } = action.payload;
+
+      state.fetchedCategoryFolder[category].splice(index, 1);
+    },
+  },
   extraReducers: {
     [fetchCategoryFolder.pending]: (state, action) => {
       state.loading = true;
@@ -101,4 +107,5 @@ const categoryFolderSlices = createSlice({
   },
 });
 
+export const { deleteUniqueCategoryFolder } = categoryFolderSlices.actions;
 export default categoryFolderSlices.reducer;

--- a/src/redux/slices/folderSlices.js
+++ b/src/redux/slices/folderSlices.js
@@ -5,7 +5,7 @@ export const fetchCreatedFolder = createAsyncThunk(
   "get/folders",
   async (payload, { rejectWithValue, getState, dispatch }) => {
     try {
-      const { data } = await req("get", "/folder/main", true, (res) => res);
+      const { data } = await req("get", "/folder/main", (res) => res, true);
 
       return data;
     } catch (error) {
@@ -18,7 +18,7 @@ export const saveFolders = createAsyncThunk(
   "post/folders",
   async (payload, { rejectWithValue, dispatch }) => {
     try {
-      await req("post", "/folder/new", { data: payload }, true, (res) => res);
+      await req("post", "/folder/new", { data: payload }, (res) => res, true);
       dispatch(fetchCreatedFolder());
     } catch (error) {
       return rejectWithValue(error.response.data);
@@ -36,7 +36,7 @@ export const deleteFolderInDB = createAsyncThunk(
         return;
       }
 
-      await req("delete", `/folder/${payload}`, { params: payload }, true, (res) => res);
+      await req("delete", `/folder/${payload}`, { params: payload }, (res) => res, true);
       dispatch(fetchCreatedFolder());
     } catch (error) {
       return rejectWithValue(error.response.data);

--- a/src/redux/slices/timerSlice.js
+++ b/src/redux/slices/timerSlice.js
@@ -1,0 +1,16 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const timerSlice = createSlice({
+  name: "timer",
+  initialState: {
+    second: process.env.REACT_APP_RANK_PAGE_LOADING_DELAY / 1000,
+  },
+  reducers: {
+    updateSecond: (state, action) => {
+      state.second += action.payload;
+    },
+  },
+});
+
+export const { updateSecond } = timerSlice.actions;
+export default timerSlice.reducer;

--- a/src/redux/store/store.js
+++ b/src/redux/store/store.js
@@ -5,7 +5,8 @@ import folderReducer from "../slices/folderSlices";
 import linkReducer from "../slices/linkSlices";
 import keywordReducer from "../slices/keywordSlices";
 import categoryFolderReducer from "../slices/categoryFolderSlices";
-import userSlices from "../slices/userSlices";
+import userReducer from "../slices/userSlices";
+import timerReducer from "../slices/timerSlice";
 
 const store = configureStore({
   reducer: {
@@ -13,7 +14,8 @@ const store = configureStore({
     categoryFolder: categoryFolderReducer,
     link: linkReducer,
     keyword: keywordReducer,
-    user: userSlices,
+    user: userReducer,
+    timer: timerReducer,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
 });

--- a/src/utils/useInterval.js
+++ b/src/utils/useInterval.js
@@ -17,5 +17,5 @@ export default function useInterval(callback, delay) {
 
       return () => clearInterval(id);
     }
-  });
+  }, [delay]);
 }


### PR DESCRIPTION
# [61][Frontend] useInterval을 사용한 로딩 시간표시 기능 및 DB에 폴더가 삭제된 경우 alert 및 리덕스 반영하는 기능구현

## Jira 칸반 링크

- https://90crew.atlassian.net/browse/MYS-61?atlOrigin=eyJpIjoiNjkzZDRiYzkxNzZiNGQ1ZmI4YzY5Mjg2OTZjZWQ4NDYiLCJwIjoiaiJ9

## 카드에서 구현 혹은 해결하려는 내용
- useInterval hook을 사용하여 5초마다 rank update 구현 
- 이미 사라진 폴더의 경우, 좋아요 요청을 보낼 수 없도록 alert 기능 및 redux store 에도 폴더 삭제하는 기능 구현

## 테스트 방법
- npm start
- npm run dev
## 기타 사항
- 에딧페이지, 랭크페이지, 개인프로필 내에 있는 폴더가 재각각이므로, 이 부분에서 재사용 및 통일성 구현 가능성 협의 필요 