### PR TITLE
HOTFIX: webpack.override.js 설정을 통한  webpack v5 대응

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,34 +1,11 @@
-const { overrideDevServer } = require("customize-cra");
+module.exports = function override(config, env) {
+  const loaders = config.resolve;
 
-function devServerConfig() {
-  return (config) => {
-    return {
-      ...config,
-      historyApiFallback: true,
-      hot: true,
-      proxy: {
-        "/api": {
-          target: "http://localhost:7001",
-          changeOrigin: true,
-          pathRewrite: {
-            "^/api": "/",
-          },
-        },
-      },
-      onBeforeSetupMiddleware: (devServer) => {
-        devServer.app.get("/api/key", (req, res) => {
-          res.json([{ key: "aaa" }]);
-        });
-      },
-    };
+  loaders.fallback = {
+    crypto: require.resolve("crypto-browserify"),
+    stream: require.resolve("stream-browserify"),
+    buffer: require.resolve("buffer"),
   };
-}
 
-module.exports = {
-  devServer: overrideDevServer(devServerConfig()),
-  resolve: {
-    fallback: {
-      crypto: require.resolve("crypto-browserify"),
-    },
-  },
+  return config;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,9 @@
         "bson": "^4.6.1",
         "crypto-browserify": "^3.12.0",
         "customize-cra": "^1.0.0",
-        "dotenv": "^16.0.0",
         "firebase": "^9.6.6",
         "js-cookie": "^3.0.1",
         "nanoid": "^3.2.0",
-        "os-browserify": "^0.3.0",
-        "path-browserify": "^1.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-loading": "^2.0.3",
@@ -30,6 +27,7 @@
         "react-router-dom": "^6.2.1",
         "react-scripts": "5.0.0",
         "redux-logger": "^3.0.6",
+        "stream-browserify": "^3.0.0",
         "styled-components": "^5.3.3"
       },
       "devDependencies": {
@@ -7260,14 +7258,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/dotenv": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
-      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/dotenv-expand": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
@@ -12847,11 +12837,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-browserify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -12989,11 +12974,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -15899,6 +15879,15 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
       }
     },
     "node_modules/string_decoder": {
@@ -23236,11 +23225,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "dotenv": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
-      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
-    },
     "dotenv-expand": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
@@ -27286,11 +27270,6 @@
         "word-wrap": "^1.2.3"
       }
     },
-    "os-browserify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
-    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -27392,11 +27371,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
-    },
-    "path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "path-exists": {
       "version": "4.0.0",
@@ -29430,6 +29404,15 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "requires": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
     "redux-logger": "^3.0.6",
+    "stream-browserify": "^3.0.0",
     "styled-components": "^5.3.3"
   },
   "scripts": {


### PR DESCRIPTION
# Webpack.override.js 설정을 통한  webpack v5 대응

## 기타사항
-webpack loader의 resolve 속성에 fallback으로 crypto, stream, buffer 추가
- crypto의 경우, bson 사용 시 필요
